### PR TITLE
Fix sparta icon and update tic-tac-toe to version 3.0

### DIFF
--- a/_apps/sparta.md
+++ b/_apps/sparta.md
@@ -2,7 +2,7 @@
 appid: com.github.jacalz.sparta
 name: Sparta
 home: https://github.com/Jacalz/sparta
-icon: https://raw.githubusercontent.com/jacalz/sparta/master/internal/assets/icon-256.png
+icon: https://raw.githubusercontent.com/Jacalz/sparta/master/internal/assets/icon-512.png
 screenshot1: https://raw.githubusercontent.com/Jacalz/sparta/master/internal/assets/screenshot.png
 
 date:      2020-06-26 14:30:00

--- a/_apps/tic-tac-toe.md
+++ b/_apps/tic-tac-toe.md
@@ -1,18 +1,18 @@
 ---
-appid: com.github.jacalz.tic-tac-toe
+appid: com.github.jacalz.fyne-board-games.tic-tac-toe
 name: Tic-tac-Toe
-home: https://github.com/Jacalz/go-projects/tree/master/school/tic-tac-toe
-icon: https://github.com/jacalz/go-projects/blob/master/school/tic-tac-toe/assets/fyne-app-icon.png?raw=true
-screenshot1: https://github.com/jacalz/go-projects/blob/master/school/tic-tac-toe/assets/tic-tac-toe.png?raw=true
+home: https://github.com/Jacalz/fyne-board-games
+icon: https://raw.githubusercontent.com/Jacalz/fyne-board-games/master/tic-tac-toe/assets/bundle/icon-512.png
+screenshot1: https://raw.githubusercontent.com/Jacalz/fyne-board-games/master/tic-tac-toe/assets/screenshot.png
 
 date:      2020-02-19 14:42:00
 excerpt:   A simple tic-tac-toe game built using Fyne.
 category:  game
 developer: Jacalz
 
-git: https://github.com/Jacalz/go-projects.git
-package: github.com/Jacalz/go-projects/school/tic-tac-toe
-version: 2.0
+git: https://github.com/Jacalz/fyne-board-games.git
+package: github.com/Jacalz/fyne-board-games/tic-tac-toe
+version: 3.0
 ---
 
-A simple tic-tac-toe game that was developed as part of a school project.
+A simple local two player game of tic-tac-toe. It was originally built as part of a school project.


### PR DESCRIPTION
This commit fixes the sparta icon path to be the 512px icon (broke it when I cleaned up inside my repo) and it also updates the information in tic-tac-toe to point to the newly rewritten 3.0 version.