### PR TITLE
Unbreak and update wormhole-gui for the 2.0.0 release

### DIFF
--- a/_apps/wormhole-gui.md
+++ b/_apps/wormhole-gui.md
@@ -12,7 +12,7 @@ developer: Jacalz
 
 git: https://github.com/Jacalz/wormhole-gui.git
 package: github.com/Jacalz/wormhole-gui
-version: 1.2.0
+version: 2.0.0
 ---
 
 Wormhole-gui is a cross-platform graphical interface for magic-wormhole that lets you share files, folders and text between computers. It uses the Go implementation [wormhole-william](https://github.com/psanford/wormhole-william) for sharing data and uses [fyne](https://github.com/fyne-io/fyne) for the graphical interface. The initial version was built in less than one day to show how quick and easy it is to use fyne for developing applications. The application has since developed into a more feature-full cross-platform application for sharing files and text between devices on the local network.

--- a/_apps/wormhole-gui.md
+++ b/_apps/wormhole-gui.md
@@ -2,11 +2,11 @@
 appid: com.github.jacalz.wormhole-gui
 name: wormhole-gui
 home: https://github.com/Jacalz/wormhole-gui
-icon: https://raw.githubusercontent.com/Jacalz/wormhole-gui/master/assets/icon-512.png
-screenshot1: https://raw.githubusercontent.com/Jacalz/wormhole-gui/master/assets/screenshot.png
+icon: https://raw.githubusercontent.com/Jacalz/wormhole-gui/main/internal/assets/icon/icon-512.png
+screenshot1: https://raw.githubusercontent.com/Jacalz/wormhole-gui/main/internal/assets/screenshot.png
 
-date:      2020-06-26 14:35:00
-excerpt:   A graphical user-interface for wormhole-william written in Go.
+date:      2020-11-09 20:08:00
+excerpt:   Graphical user interface for easy encrypted sharing of files, folders, and text between devices on a local network. 
 category:  utility
 developer: Jacalz
 
@@ -15,4 +15,4 @@ package: github.com/Jacalz/wormhole-gui
 version: 1.2.0
 ---
 
-Wormhole-gui is a graphical interface for magic-wormhole. It uses the Go implementation [wormhole-william](https://github.com/psanford/wormhole-william) along with [fyne](https://github.com/fyne-io/fyne) for the graphical interface. The initial version was built in less than one day to show how quick and easy it is to use fyne for developing applications.
+Wormhole-gui is a cross-platform graphical interface for magic-wormhole that lets you share files, folders and text between computers. It uses the Go implementation [wormhole-william](https://github.com/psanford/wormhole-william) for sharing data and uses [fyne](https://github.com/fyne-io/fyne) for the graphical interface. The initial version was built in less than one day to show how quick and easy it is to use fyne for developing applications. The application has since developed into a more feature-full cross-platform application for sharing files and text between devices on the local network.


### PR DESCRIPTION
This fixes and updated the wormhole-gui example to work after the 2.0.0 release changes.