### PR TITLE
fix hyperlinks

### DIFF
--- a/support.md
+++ b/support.md
@@ -3,6 +3,6 @@ layout: page
 title:  "Fyne Apps Support"
 ---
 
-To learn more about building an app that could be listed on this page check out our [developer documentation](https://fyne.io/develop/).
+To learn more about building an app that could be listed on this page check out our [developer documentation](https://developer.fyne.io/).
 
-If you are looking for more assistance then check out the various ways you can [get support](https://fyne.io/develop/#contact).
+If you are looking for more assistance then check out the various ways you can [get support](https://fyne.io/support/#contact).


### PR DESCRIPTION
Replaced the support URL, and removed the redirect on the develop URL.

Closes #10 
