### PR TITLE
Update wormhole-gui in preparation for the 2.3.0 release

### DIFF
--- a/_apps/wormhole-gui.md
+++ b/_apps/wormhole-gui.md
@@ -7,13 +7,16 @@ screenshots:
 - url: https://raw.githubusercontent.com/Jacalz/wormhole-gui/main/internal/assets/screenshot.png
 
 date:      2020-11-09 20:08:00
-excerpt:   Graphical user interface for easy encrypted sharing of files, folders, and text between devices on a local network. 
+excerpt:   Cross-platform application for easy encrypted sharing of files, folders, and text between devices.
 category:  utility
 developer: Jacalz
 
 git: https://github.com/Jacalz/wormhole-gui.git
-package: github.com/Jacalz/wormhole-gui
-version: 2.0.0
+package: github.com/Jacalz/wormhole-gui/v2
+version: 2.3.0
 ---
 
-Wormhole-gui is a cross-platform graphical interface for magic-wormhole that lets you share files, folders and text between computers. It uses the Go implementation [wormhole-william](https://github.com/psanford/wormhole-william) for sharing data and uses [fyne](https://github.com/fyne-io/fyne) for the graphical interface. The initial version was built in less than one day to show how quick and easy it is to use fyne for developing applications. The application has since developed into a more feature-full cross-platform application for sharing files and text between devices on the local network.
+Wormhole-gui is a cross-platform application that lets you easily share files, folders and text between devices.
+It uses the Go implementation of magic-wormhole, called [wormhole-william](https://github.com/psanford/wormhole-william), and compiles statically into a single binary. Wormhole-gui is also compatible with sending to and receiving from other wormhole clients, such as the cli applications from both [wormhole-william](https://github.com/psanford/wormhole-william) and [magic-wormhole](https://github.com/magic-wormhole/magic-wormhole).
+
+The initial version was built in less than one day to show how quick and easy it is to use [fyne](https://github.com/fyne-io/fyne) for developing applications.


### PR DESCRIPTION
Wording changes and improvements in preparation for the 2.3.0 release. It also fixes the v2 module path. It turns out that it hasn't been possible to download wormhole-gui 2.0.0 and later because of this issue but it is finally fixed and will be in the next release. I have always used the make commands for installation locally and never really had any reason to try and `go get` it and nobody complained about it :)